### PR TITLE
Fix undefined context reference in utils

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,9 @@ var notes = {
   "b": 11
 };
 
+// Use a global context if it exists, or create a utility one if it does not.
+var utilContext = window.context || new AudioContext();
+
 function mtof(midi_note) {
   console.log();
   return Math.pow(2, (midi_note - 69) / 12) * 440;
@@ -44,7 +47,7 @@ module.exports.load = function (path, success, failure) {
   request.open('GET', path, true);
   request.responseType = 'arraybuffer';
   request.onload = function () {
-    context.decodeAudioData(request.response, success, failure);
+    utilContext.decodeAudioData(request.response, success, failure);
   };
   request.onerror = failure;
   request.send();


### PR DESCRIPTION
The utils load method seems to expect a global context object. The other approach might be to add a context argument to the method.

``` js
module.exports.load = function (path, success, failure, context) {
  context = context || window.context || new AudioContext();
  ...
}
```
