### PR TITLE
Support string sequence when creating layers

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -7,6 +7,11 @@ function Layer(context, tempo, sequence, on, off) {
   this.on = on;
   this.off = off;
   this.tempo = tempo;
+  
+  if (typeof sequence === 'string') {
+    sequence = {seq: sequence.split('')};
+  }
+  
   self.metro = new Metro(context, function (time, step, timeFromScheduled) {
     if (self.metro.steps !== sequence.seq.length) {
       self.metro.steps = sequence.seq.length;


### PR DESCRIPTION
Lets you pass in '0110', for instance.

Use:
```js
  var kick  = beet.layer('10001000', playKick);
  var snare = beet.layer('00100010', playSnare);
  var hat   = beet.layer('10101010', playSnare);
```