### PR TITLE
Use array concat for Beet.add(layer);

### DIFF
--- a/lib/beet.js
+++ b/lib/beet.js
@@ -25,8 +25,8 @@ Beet.prototype.pattern = function(pulses, steps) {
   return pattern;
 };
 
-Beet.prototype.add = function(layer) {
-  this.layers.push(layer);
+Beet.prototype.add = function(/* layer(s) */) {
+  this.layers.concat(arguments);
   return this;
 };
 


### PR DESCRIPTION
Allows multiple layers to be added as multiple arguments.

```js
beet.add(layer1, layer2, layer3);
```

Adds some convenience, instead of requiring the use of an array. 
```js
[layer1, layer2, layer3].forEach(beet.add);
```